### PR TITLE
include remote error_description in error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -212,7 +212,8 @@ GoogleToken.prototype._requestToken = function(callback) {
         body = {};
       }
 
-      err = err || body.error && new Error(body.error);
+      err = err || body.error && new Error(body.error +
+          (body.error_description ? ': ' + body.error_description : ''));
 
       if (err) {
         self.token = null;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "request": "^2.72.0"
   },
   "devDependencies": {
-    "mocha": "^2.0.1"
+    "mocha": "^3.4.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -371,6 +371,30 @@ describe('gtoken', function() {
           done();
         });
       });
+
+      it('should include error_description from remote error', function(done) {
+        var gtoken = GoogleToken(TESTDATA);
+        var ERROR = 'error_name';
+        var DESCRIPTION = 'more detailed message';
+        var RESPBODY = JSON.stringify({
+          error: ERROR,
+          error_description: DESCRIPTION
+        });
+
+        gtoken._request = function(options, callback) {
+          callback(null, {}, RESPBODY);
+        };
+
+        gtoken._signJWT = function(opts, callback) {
+          callback(null, 'signedJWT123');
+        };
+
+        gtoken.getToken(function(err, token) {
+          assert(err instanceof Error);
+          assert.equal(err.message, ERROR + ': ' + DESCRIPTION);
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
OAuth endpoint provides a more detailed error message in the body. It
is useful to include this in the JS error returned.

Fixes: https://github.com/ofrobots/node-gtoken/issues/9